### PR TITLE
Fix flush drop after halt

### DIFF
--- a/stream_processor/engine/processor.py
+++ b/stream_processor/engine/processor.py
@@ -166,16 +166,20 @@ class StreamProcessor:
         """
         Flush and return all remaining buffered characters.
 
-        If a HALT decision occurred, returns the buffer as-is (no drop-mode or
-        keyword contents), otherwise applies drop-mode or normal flush logic.
+        If a HALT decision occurred, returns the buffer as-is unless drop mode
+        is active. When drop mode is active after a halt, all buffered
+        characters are discarded. Otherwise applies drop-mode or normal flush
+        logic.
 
         Returns:
             Remaining characters to emit after processing the entire input.
         """
-        # If halted, emit whatever remains in the buffer
+        # If halted, emit remaining buffer unless drop mode is active
         if getattr(self, '_halted', False):
             rem = list(self._buffer)
             self._buffer.clear()
+            if self._drop_mode:
+                return []
             return rem
         # If in drop mode, discard all buffered characters
         if self._drop_mode:

--- a/tests/test_stream_processor.py
+++ b/tests/test_stream_processor.py
@@ -150,6 +150,13 @@ class TestProcessor(unittest.TestCase):
         reg.register('stop', halt)
         self.assertEqual(self.run_seq(reg, 'abstopcd'), 'ab')
 
+    def test_halt_during_drop_mode(self):
+        reg = KeywordRegistry()
+        reg.register('<s>', continuous_drop)
+        reg.register('stop', halt)
+        txt = 'ab<s>cdstop'
+        self.assertEqual(self.run_seq(reg, txt), 'ab')
+
     def test_continuous(self):
         reg = KeywordRegistry()
         reg.register('<s>', continuous_drop)


### PR DESCRIPTION
## Summary
- flush should respect drop mode when the processor halted
- add regression test for halting while in a drop segment

## Testing
- `PYTHONPATH=. pytest -q`
